### PR TITLE
feat: link categories in homepage to itemspage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useState } from 'react';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import Layout from './components/Layout';
 import ItemsPage from './pages/ItemsPage';
@@ -14,6 +14,9 @@ import SingleItemPage from './pages/SingleItemPage/SingleItemPage';
 import ContactUsPage from './pages/ContactUsPage';
 
 function App() {
+  const [query, setQuery] = useState('');
+  console.log('query', query);
+
   return (
     <div className="App">
       <Router>
@@ -21,7 +24,7 @@ function App() {
           <Layout>
             <Switch>
               <Route exact path="/">
-                <HomePage />
+                <HomePage setQuery={setQuery} />
               </Route>
               <Route exact path="/auth/signin">
                 <SignInPage />

--- a/src/components/CategoryCard/CategoryCard.jsx
+++ b/src/components/CategoryCard/CategoryCard.jsx
@@ -1,29 +1,31 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Flex, Stack, Text, Image } from '@chakra-ui/react';
 
 const CategoryCard = ({ categoryPic, direction, categoryName, ml, mt }) => {
   return (
-    <Flex
-      mb="4"
-      fontSize="md"
-      Width="100%"
-      height="100%"
-      justifyContent="center"
-      _hover={{ cursor: 'pointer' }}
-    >
-      <Stack direction={direction} mb="4">
-        <Image src={categoryPic} maxW="90%" maxH="90%" m="auto" />
-
-        <Stack>
-          <Flex mt={mt} justify="left">
-            <Text fontWeight={600} ml={ml} mr="2">
-              {categoryName}
-            </Text>
-            <Text color="gray.400">55</Text>
-          </Flex>
+    <Link to={`/items?category=${categoryName.toLowerCase()}`}>
+      <Flex
+        mb="4"
+        fontSize="md"
+        Width="100%"
+        height="100%"
+        justifyContent="center"
+        _hover={{ cursor: 'pointer' }}
+      >
+        <Stack direction={direction} mb="4">
+          <Image src={categoryPic} maxW="90%" maxH="90%" m="auto" />
+          <Stack>
+            <Flex mt={mt} justify="left">
+              <Text fontWeight={600} ml={ml} mr="2">
+                {categoryName}
+              </Text>
+              <Text color="gray.400">55</Text>
+            </Flex>
+          </Stack>
         </Stack>
-      </Stack>
-    </Flex>
+      </Flex>
+    </Link>
   );
 };
 

--- a/src/components/CategoryCardsLayout/CategoryCardsLayout.jsx
+++ b/src/components/CategoryCardsLayout/CategoryCardsLayout.jsx
@@ -8,7 +8,7 @@ import toys from '../../assets/images/toys.png';
 import medicalkit from '../../assets/images/medicalkit.png';
 import appliances from '../../assets/images/appliances.png';
 
-const CategoryCardsLayout = () => {
+const CategoryCardsLayout = ({ setQuery }) => {
   return (
     <Flex>
       <Grid
@@ -18,7 +18,13 @@ const CategoryCardsLayout = () => {
         templateColumns="repeat(25, 1fr)"
         gap={4}
       >
-        <GridItem borderRadius="xl" colSpan={8} rowSpan={12} bg="#EAEAF1">
+        <GridItem
+          onClick={() => setQuery('furniture')}
+          borderRadius="xl"
+          colSpan={8}
+          rowSpan={12}
+          bg="#EAEAF1"
+        >
           <CategoryCard
             categoryPic={sofa}
             direction="column"
@@ -26,21 +32,39 @@ const CategoryCardsLayout = () => {
             ml="4"
           ></CategoryCard>
         </GridItem>
-        <GridItem borderRadius="xl" colSpan={5} rowSpan={6} bg="#F6E8CD">
+        <GridItem
+          onClick={() => setQuery('clothes')}
+          borderRadius="xl"
+          colSpan={5}
+          rowSpan={6}
+          bg="#F6E8CD"
+        >
           <CategoryCard
             categoryPic={Clothes}
             direction="column"
             categoryName="Clothes"
           ></CategoryCard>
         </GridItem>
-        <GridItem borderRadius="xl" colSpan={5} rowSpan={6} bg="#CBECE9">
+        <GridItem
+          onClick={() => setQuery('books')}
+          borderRadius="xl"
+          colSpan={5}
+          rowSpan={6}
+          bg="#CBECE9"
+        >
           <CategoryCard
             categoryPic={book}
             direction="column"
             categoryName="Books"
           ></CategoryCard>
         </GridItem>
-        <GridItem borderRadius="xl" colSpan={7} rowSpan={6} bg="#E6D0EF">
+        <GridItem
+          onClick={() => setQuery('toys')}
+          borderRadius="xl"
+          colSpan={7}
+          rowSpan={6}
+          bg="#E6D0EF"
+        >
           <CategoryCard
             categoryPic={toys}
             direction="row-reverse"
@@ -48,7 +72,13 @@ const CategoryCardsLayout = () => {
             mt="24"
           ></CategoryCard>
         </GridItem>
-        <GridItem borderRadius="xl" colSpan={7} rowSpan={6} bg="#F0D0D2">
+        <GridItem
+          onClick={() => setQuery('medics')}
+          borderRadius="xl"
+          colSpan={7}
+          rowSpan={6}
+          bg="#F0D0D2"
+        >
           <CategoryCard
             categoryPic={medicalkit}
             direction="row-reverse"
@@ -56,7 +86,13 @@ const CategoryCardsLayout = () => {
             mt="24"
           ></CategoryCard>
         </GridItem>
-        <GridItem borderRadius="xl" colSpan={10} rowSpan={6} bg="#CFD6F2">
+        <GridItem
+          onClick={() => setQuery('appliances')}
+          borderRadius="xl"
+          colSpan={10}
+          rowSpan={6}
+          bg="#CFD6F2"
+        >
           <CategoryCard
             categoryPic={appliances}
             direction="row-reverse"

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -3,7 +3,7 @@ import { Box } from '@chakra-ui/react';
 import HeroSection from '../components/HeroSection';
 import CategoryCardLayout from '../components/CategoryCardsLayout';
 import CardList from '../components/CardList';
-function HomePage() {
+function HomePage({ setQuery }) {
   return (
     <div>
       <Box maxWidth="1080px" mx="auto">
@@ -11,7 +11,7 @@ function HomePage() {
           <HeroSection />
         </Box>
         <Box marginBottom="30px">
-          <CategoryCardLayout />
+          <CategoryCardLayout setQuery={setQuery} />
         </Box>
         <Box marginBottom="40px">
           <CardList />


### PR DESCRIPTION
This is a proof of concept of what I'm trying to pull off - I'm aware it's not the cleanest implementation

I believe this is a really challenging one and I'll most likely need help when I'll have to turn it into a fully fledged feature

See, we have `'/items'` route which is accommodated by its own component - What I'm trying to do is append a queryString to the URL dynamically whenever a certain category is clicked so it would look something like this `'/items?category=furniture'` - I sort of hijacked it now by manipulating the `<Link />` component offered by react-router-dom but I'm aware this is not the cleanest implementation and I should resort to using the `URLSearchParams()` and leverage its API in order to append the category name as a queryString to the URL

I'm not sure if I'm overcomplicating things because this seems to be a challenging feature for me - I kinda have the thought process down in my head but I'm unable to connect the dots properly

Please take your time to go through the code I implemented - any feedback is highly appreciated 

Apologies for the long paragraph 